### PR TITLE
Added support to the same level dir attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,8 @@ function generator({ addVariant, e }) {
 		['ltr', 'rtl'].forEach(dir => {
 			result.nodes = result.nodes.concat(
 				addSelectors(container, className => {
-					return `[dir='${dir}'] .${dir}${e(separator)}${className}`;
+					return [`[dir='${dir}'] .${dir}${e(separator)}${className}`,
+					` [dir='${dir}'].${dir}${e(separator)}${className}`];
 				})
 			);
 		});

--- a/tests/variantGenerator.test.js
+++ b/tests/variantGenerator.test.js
@@ -19,19 +19,23 @@ test('it generates direction variants', () => {
 			color: red;
 		}
 
-		[dir='ltr'] .ltr\\:banana {
+		[dir='ltr'] .ltr\\:banana,
+		[dir='ltr'].ltr\\:banana {
 			color: yellow;
 		}
 
-		[dir='ltr'] .ltr\\:tomato {
+		[dir='ltr'] .ltr\\:tomato,
+		[dir='ltr'].ltr\\:tomato {
 			color: red;
 		}
 
-		[dir='rtl'] .rtl\\:banana {
+		[dir='rtl'] .rtl\\:banana,
+		[dir='rtl'].rtl\\:banana {
 			color: yellow;
 		}
 
-		[dir='rtl'] .rtl\\:tomato {
+		[dir='rtl'] .rtl\\:tomato,
+		[dir='rtl'].rtl\\:tomato {
 			color: red;
 		}
 	`;


### PR DESCRIPTION
Thank you so much for this awesome plugin

I figured that sometimes I need to add some specific styling to the same level `div` I added the `dir="rtl"` attribute to it. as follows:
```html
<div className="border p-2 ltr:pl-4 rtl:pr-4" dir="rtl">
  <h1 className="font-bold text-2xl">This it RTL Text</h1>
  <p>Lorem Ipsum ...</p>
</div>
```
but the css is targeting only the next level items:
```css
[dir='rtl'] .rtl\:pr-4 {
  padding-right: 1rem;
}
[dir='ltr'] .ltr\:pl-4 {
  padding-left: 1rem;
}
```

so I added the also the needed selector:
```css
[dir='rtl'] .rtl\:pr-4,
[dir='rtl'].rtl\:pr-4 {
  padding-right: 1rem;
}
[dir='ltr'] .ltr\:pl-4,
[dir='ltr'].ltr\:pl-4 {
  padding-left: 1rem;
}
```

Thanks again.