### PR TITLE
updated selector to remove the [dir='ltr'] syntax for ltr sytles, because dir="ltr" is usually not added to the html.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,20 @@ function generator({ addVariant, e }) {
 		['ltr', 'rtl'].forEach(dir => {
 			result.nodes = result.nodes.concat(
 				addSelectors(container, className => {
-					return [
-						`[dir='${dir}'] .${dir}${e(separator)}${className}`,
-						`[dir='${dir}'].${dir}${e(separator)}${className}`,
-					];
+					let newSelector = [];
+					if(dir == 'rtl'){
+						newSelector = [
+							`[dir='${dir}'] .${dir}${e(separator)}${className}`,
+							`[dir='${dir}'].${dir}${e(separator)}${className}`,
+						];
+						
+					}else{
+						newSelector = [
+							`${dir}${e(separator)}${className}`,
+						];
+					}
+
+					return newSelector;
 				})
 			);
 		});


### PR DESCRIPTION
This was causing an issue when dir="ltr" is not added to the HTML tag even though it is the default 